### PR TITLE
Colour conversion using DeckLink SDK.

### DIFF
--- a/example/ofApp.xcodeproj/project.pbxproj
+++ b/example/ofApp.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		E7E077E515D3B63C0020DFD4 /* CoreVideo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E7E077E415D3B63C0020DFD4 /* CoreVideo.framework */; };
 		E7E077E815D3B6510020DFD4 /* QTKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E7E077E715D3B6510020DFD4 /* QTKit.framework */; };
 		E7F985F815E0DEA3003869B5 /* Accelerate.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E7F985F515E0DE99003869B5 /* Accelerate.framework */; };
+		F3003DDD1B3213A100B07B83 /* VideoFrame.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F3003DDB1B3213A100B07B83 /* VideoFrame.cpp */; };
 		FF2A09A9D39D58C1556A39E0 /* DeckLinkController.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1716A5684BC3EB831AC8B6BA /* DeckLinkController.cpp */; };
 /* End PBXBuildFile section */
 
@@ -100,6 +101,8 @@
 		E7E077E415D3B63C0020DFD4 /* CoreVideo.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreVideo.framework; path = /System/Library/Frameworks/CoreVideo.framework; sourceTree = "<absolute>"; };
 		E7E077E715D3B6510020DFD4 /* QTKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QTKit.framework; path = /System/Library/Frameworks/QTKit.framework; sourceTree = "<absolute>"; };
 		E7F985F515E0DE99003869B5 /* Accelerate.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Accelerate.framework; path = /System/Library/Frameworks/Accelerate.framework; sourceTree = "<absolute>"; };
+		F3003DDB1B3213A100B07B83 /* VideoFrame.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = VideoFrame.cpp; path = ../src/VideoFrame.cpp; sourceTree = "<group>"; };
+		F3003DDC1B3213A100B07B83 /* VideoFrame.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = VideoFrame.h; path = ../src/VideoFrame.h; sourceTree = "<group>"; };
 		F32E0062C7902184B545B994 /* DeckLinkAPIDeckControl.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 30; name = DeckLinkAPIDeckControl.h; path = ../../../addons/ofxBlackMagic/libs/DeckLink/include/DeckLinkAPIDeckControl.h; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
 
@@ -166,6 +169,8 @@
 				22DBCF6B53F1127EAD052CA5 /* TripleBuffer.h */,
 				273629921820E91D00CB625E /* ColorConversion.cpp */,
 				273629931820E91D00CB625E /* ColorConversion.h */,
+				F3003DDB1B3213A100B07B83 /* VideoFrame.cpp */,
+				F3003DDC1B3213A100B07B83 /* VideoFrame.h */,
 			);
 			name = src;
 			sourceTree = "<group>";
@@ -371,6 +376,7 @@
 				273629941820E91D00CB625E /* ColorConversion.cpp in Sources */,
 				0B06AF481628430095F582FA /* ofxBlackMagic.cpp in Sources */,
 				2413480B948EEA290CED44D2 /* DeckLinkAPIDispatch.cpp in Sources */,
+				F3003DDD1B3213A100B07B83 /* VideoFrame.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/src/DeckLinkController.cpp
+++ b/src/DeckLinkController.cpp
@@ -336,7 +336,7 @@ HRESULT DeckLinkController::VideoInputFrameArrived (/* in */ IDeckLinkVideoInput
         rgbaFrame = new VideoFrame(videoFrame->GetWidth(), videoFrame->GetHeight());
     }
     
-    if (rgbaFrame->lock.tryLock(500)) {
+    if (rgbaFrame->lock.tryLock(VIDEO_CONVERSION_TRYLOCK_TIMEOUT)) {
         videoConverter->ConvertFrame(videoFrame, rgbaFrame);
         rgbaFrame->lock.unlock();
     }

--- a/src/DeckLinkController.cpp
+++ b/src/DeckLinkController.cpp
@@ -147,6 +147,10 @@ bail:
 	return result;
 }
 
+void DeckLinkController::setColorConversionTimeout(int ms)  {
+    colorConversionTimeout = ms;
+}
+
 vector<string> DeckLinkController::getDisplayModeNames()  {
 	vector<string> modeNames;
 	int modeIndex;
@@ -336,7 +340,7 @@ HRESULT DeckLinkController::VideoInputFrameArrived (/* in */ IDeckLinkVideoInput
         rgbaFrame = new VideoFrame(videoFrame->GetWidth(), videoFrame->GetHeight());
     }
     
-    if (rgbaFrame->lock.tryLock(VIDEO_CONVERSION_TRYLOCK_TIMEOUT)) {
+    if (rgbaFrame->lock.tryLock(colorConversionTimeout)) {
         videoConverter->ConvertFrame(videoFrame, rgbaFrame);
         rgbaFrame->lock.unlock();
     }

--- a/src/DeckLinkController.h
+++ b/src/DeckLinkController.h
@@ -13,13 +13,6 @@
 #include "TripleBuffer.h"
 #include "VideoFrame.h"
 
-// Lock timeout duration.
-// The lock is necessary to prevent reading from the VideoFrame whilst writing to it.
-// A value 500 milliseconds would be for a 'frame critical' application, as a value of 66 milliseconds would be for a 'latency critical' application.
-// Run tests to determine what timeout value you need.
-// See PR #8 - https://github.com/kylemcdonald/ofxBlackmagic/pull/8
-#define VIDEO_CONVERSION_TRYLOCK_TIMEOUT 500
-
 class VideoFrame;
 
 class DeckLinkController : public IDeckLinkInputCallback {
@@ -33,6 +26,7 @@ private:
 	bool currentlyCapturing;
     
     IDeckLinkVideoConversion *videoConverter;
+    int colorConversionTimeout;
 	
 	void getAncillaryDataFromFrame(IDeckLinkVideoInputFrame* frame, BMDTimecodeFormat format, string& timecodeString, string& userBitsString);
 	
@@ -48,6 +42,7 @@ public:
 	vector<string> getDeviceNameList();
 	
 	bool selectDevice(int index);
+    void setColorConversionTimeout(int ms);
 	
 	vector<string> getDisplayModeNames();
 	bool isFormatDetectionEnabled();

--- a/src/DeckLinkController.h
+++ b/src/DeckLinkController.h
@@ -13,6 +13,11 @@
 #include "TripleBuffer.h"
 #include "VideoFrame.h"
 
+// The value comes from the addon ofxBlackMagic2 by Elliot Woods.
+// I need to ask him why he picked that value, and I need to run more tests to understand why half a second timeout is necessary.
+// See PR #8 - https://github.com/kylemcdonald/ofxBlackmagic/pull/8
+#define VIDEO_CONVERSION_TRYLOCK_TIMEOUT 500
+
 class VideoFrame;
 
 class DeckLinkController : public IDeckLinkInputCallback {

--- a/src/DeckLinkController.h
+++ b/src/DeckLinkController.h
@@ -11,6 +11,9 @@
 
 #include "DeckLinkAPI.h"
 #include "TripleBuffer.h"
+#include "VideoFrame.h"
+
+class VideoFrame;
 
 class DeckLinkController : public IDeckLinkInputCallback {
 private:
@@ -21,6 +24,8 @@ private:
 	
 	bool supportFormatDetection;
 	bool currentlyCapturing;
+    
+    IDeckLinkVideoConversion *videoConverter;
 	
 	void getAncillaryDataFromFrame(IDeckLinkVideoInputFrame* frame, BMDTimecodeFormat format, string& timecodeString, string& userBitsString);
 	
@@ -56,4 +61,6 @@ public:
     
 	BMDDisplayMode getDisplayMode(int w, int h);
 	BMDDisplayMode getDisplayMode(int w, int h, float framerate);
+    
+    VideoFrame *rgbaFrame;
 };

--- a/src/DeckLinkController.h
+++ b/src/DeckLinkController.h
@@ -13,8 +13,10 @@
 #include "TripleBuffer.h"
 #include "VideoFrame.h"
 
-// The value comes from the addon ofxBlackMagic2 by Elliot Woods.
-// I need to ask him why he picked that value, and I need to run more tests to understand why half a second timeout is necessary.
+// Lock timeout duration.
+// The lock is necessary to prevent reading from the VideoFrame whilst writing to it.
+// A value 500 milliseconds would be for a 'frame critical' application, as a value of 66 milliseconds would be for a 'latency critical' application.
+// Run tests to determine what timeout value you need.
 // See PR #8 - https://github.com/kylemcdonald/ofxBlackmagic/pull/8
 #define VIDEO_CONVERSION_TRYLOCK_TIMEOUT 500
 

--- a/src/VideoFrame.cpp
+++ b/src/VideoFrame.cpp
@@ -1,0 +1,68 @@
+#include "VideoFrame.h"
+
+VideoFrame::VideoFrame(long width, long height)
+{
+    this->data = 0;
+    allocate(width, height);
+}
+
+VideoFrame::~VideoFrame()
+{
+    this->deallocate();
+}
+
+void VideoFrame::allocate(int width, int height) {
+    this->deallocate();
+    //we offset to store 1 byte either side of RGB so we can do ARGB and RGBA addressing
+    this->data = new unsigned char[width * height * 4 + 1];
+    this->pixels.setFromExternalPixels(this->data + 1, width, height, 4);
+    *(data + this->pixels.size()) = 255; // set alpha channel of last byte
+}
+
+void VideoFrame::deallocate() {
+    if (this->data != 0) {
+        delete[] this->data;
+        this->data = 0;
+    }
+}
+
+int VideoFrame::getWidth() {
+    return this->pixels.getWidth();
+}
+
+int VideoFrame::getHeight() {
+    return this->pixels.getHeight();
+}
+
+unsigned char* VideoFrame::getPixels() {
+    return this->pixels.getPixels();
+}
+
+ofPixels& VideoFrame::getPixelsRef() {
+    return this->pixels;
+}
+
+long VideoFrame::GetWidth() {
+    return this->pixels.getWidth();
+}
+
+long VideoFrame::GetHeight() {
+    return this->pixels.getHeight();
+}
+
+long VideoFrame::GetRowBytes() {
+    return this->GetWidth() * 4;
+}
+
+BMDPixelFormat VideoFrame::GetPixelFormat() {
+    return bmdFormat8BitARGB;
+}
+
+BMDFrameFlags VideoFrame::GetFlags() {
+    return 0;
+}
+
+HRESULT VideoFrame::GetBytes(void **buffer) {
+    *buffer = this->data;
+    return S_OK;
+}

--- a/src/VideoFrame.h
+++ b/src/VideoFrame.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include "ofMain.h"
+
+#include "DeckLinkController.h"
+
+class VideoFrame : public IDeckLinkVideoFrame, public ofBaseHasPixels {
+private:
+    ofPixels pixels;
+    unsigned char* data;
+    
+    //override these methods for virtual
+    virtual long GetWidth (void);
+    virtual long GetHeight (void);
+    virtual long GetRowBytes (void);
+    virtual BMDPixelFormat GetPixelFormat (void);
+    virtual BMDFrameFlags GetFlags (void);
+    virtual HRESULT GetBytes (/* out */ void **buffer);
+    
+    //Dummy implementations of remaining virtual methods
+    virtual HRESULT GetTimecode (/* in */ BMDTimecodeFormat format, /* out */ IDeckLinkTimecode **timecode) { return E_NOINTERFACE; };
+    virtual HRESULT GetAncillaryData (/* out */ IDeckLinkVideoFrameAncillary **ancillary) { return E_NOINTERFACE; } ;
+    
+    // IUnknown interface (dummy implementation)
+    virtual HRESULT QueryInterface (REFIID iid, LPVOID *ppv) {return E_NOINTERFACE;}
+    virtual ULONG AddRef () {return 1;}
+    virtual ULONG Release () {return 1;}
+
+public:
+    
+    VideoFrame(long width, long height);
+    virtual ~VideoFrame();
+    
+    void allocate(int width, int height);
+    void deallocate();
+    void copyFromFrame(IDeckLinkVideoFrame*);
+    
+    int getWidth();
+    int getHeight();
+    
+    ofMutex lock;
+    
+    unsigned char* getPixels();
+    ofPixels& getPixelsRef();
+};

--- a/src/ofxBlackMagic.cpp
+++ b/src/ofxBlackMagic.cpp
@@ -10,7 +10,7 @@ ofxBlackMagic::ofxBlackMagic()
 ,colorTexOld(true) {
 }
 
-bool ofxBlackMagic::setup(int width, int height, float framerate) {
+bool ofxBlackMagic::setup(int width, int height, float framerate, ColorFrameCaptureMode colorFrameCaptureMode) {
 	if(!controller.init()) {
 		return false;
 	}
@@ -26,8 +26,22 @@ bool ofxBlackMagic::setup(int width, int height, float framerate) {
 	if(!controller.startCaptureWithMode(displayMode)) {
 		return false;
 	}
+    
+    this->colorFrameCaptureMode = colorFrameCaptureMode;
+    controller.setColorConversionTimeout(this->colorFrameCaptureMode);
+    
 	this->width = width, this->height = height;
+    
 	return true;
+}
+
+void ofxBlackMagic::setColorFrameCaptureMode(ColorFrameCaptureMode colorFrameCaptureMode) {
+    this->colorFrameCaptureMode = colorFrameCaptureMode;
+    controller.setColorConversionTimeout(this->colorFrameCaptureMode);
+}
+
+ofxBlackMagic::ColorFrameCaptureMode ofxBlackMagic::getColorFrameCaptureMode() {
+    return colorFrameCaptureMode;
 }
 
 void ofxBlackMagic::close() {
@@ -68,7 +82,7 @@ ofPixels& ofxBlackMagic::getColorPixels() {
 //		colorPixOld = false;
         
         if (controller.rgbaFrame) {
-            if (controller.rgbaFrame->lock.tryLock(VIDEO_CONVERSION_TRYLOCK_TIMEOUT)) {
+            if (controller.rgbaFrame->lock.tryLock(colorFrameCaptureMode)) {
                 colorPix = controller.rgbaFrame->getPixelsRef();
                 controller.rgbaFrame->lock.unlock();
                 colorPixOld = false;

--- a/src/ofxBlackMagic.cpp
+++ b/src/ofxBlackMagic.cpp
@@ -62,10 +62,18 @@ ofPixels& ofxBlackMagic::getGrayPixels() {
 
 ofPixels& ofxBlackMagic::getColorPixels() {
 	if(colorPixOld) {
-		colorPix.allocate(width, height, OF_IMAGE_COLOR);
-		unsigned int n = width * height;
-		cby0cry1_to_rgb(&(getYuvRaw()[0]), colorPix.getPixels(), n);
-		colorPixOld = false;
+//		colorPix.allocate(width, height, OF_IMAGE_COLOR);
+//		unsigned int n = width * height;
+//		cby0cry1_to_rgb(&(getYuvRaw()[0]), colorPix.getPixels(), n);
+//		colorPixOld = false;
+        
+        if (controller.rgbaFrame) {
+            if (controller.rgbaFrame->lock.tryLock(500)) {
+                colorPix = controller.rgbaFrame->getPixelsRef();
+                controller.rgbaFrame->lock.unlock();
+                colorPixOld = false;
+            }
+        }
 	}
 	return colorPix;
 }

--- a/src/ofxBlackMagic.cpp
+++ b/src/ofxBlackMagic.cpp
@@ -68,7 +68,7 @@ ofPixels& ofxBlackMagic::getColorPixels() {
 //		colorPixOld = false;
         
         if (controller.rgbaFrame) {
-            if (controller.rgbaFrame->lock.tryLock(500)) {
+            if (controller.rgbaFrame->lock.tryLock(VIDEO_CONVERSION_TRYLOCK_TIMEOUT)) {
                 colorPix = controller.rgbaFrame->getPixelsRef();
                 controller.rgbaFrame->lock.unlock();
                 colorPixOld = false;

--- a/src/ofxBlackMagic.h
+++ b/src/ofxBlackMagic.h
@@ -11,6 +11,36 @@
 #include "DeckLinkController.h"
 
 class ofxBlackMagic {
+public:
+    // Color Frame Capture Mode
+    // A lock is necessary to prevent reading from the VideoFrame whilst writing to it.
+    // A value 500 milliseconds would be for a 'frame critical' application, as a value of 75 milliseconds would be for a 'latency critical' application.
+    // See PR #8 - https://github.com/kylemcdonald/ofxBlackmagic/pull/8
+    enum ColorFrameCaptureMode {
+        LOW_LATENCY = 75,
+        NO_FRAME_DROPS = 500
+    };
+    
+    ofxBlackMagic();
+    bool setup(int width, int height, float framerate, ColorFrameCaptureMode colorFrameCaptureMode = LOW_LATENCY);
+    void setColorFrameCaptureMode(ColorFrameCaptureMode colorFrameCaptureMode); // If you want to set a custom value, you just need to cast it as ofxBlackMagic::ColorFrameCaptureMode
+    ColorFrameCaptureMode getColorFrameCaptureMode();
+    
+    void close(); // should call this in ofApp::exit()
+    bool update(); // returns true if there is a new frame
+    
+    vector<unsigned char>& getYuvRaw(); // fastest
+    ofPixels& getGrayPixels(); // fast
+    ofPixels& getColorPixels(); // slow
+    
+    ofTexture& getYuvTexture(); // fastest
+    ofTexture& getGrayTexture(); // fast
+    ofTexture& getColorTexture(); // slower
+    
+    void drawYuv(); // fastest
+    void drawGray(); // fast
+    void drawColor(); // slower
+    
 private:
 	DeckLinkController controller;
 	
@@ -20,22 +50,5 @@ private:
 	ofTexture yuvTex, grayTex, colorTex;
 	
 	int width, height;
-	
-public:
-	ofxBlackMagic();
-	bool setup(int width, int height, float framerate);
-	void close(); // should call this in ofApp::exit()
-	bool update(); // returns true if there is a new frame
-	
-	vector<unsigned char>& getYuvRaw(); // fastest
-	ofPixels& getGrayPixels(); // fast
-	ofPixels& getColorPixels(); // slow
-	
-	ofTexture& getYuvTexture(); // fastest
-	ofTexture& getGrayTexture(); // fast
-	ofTexture& getColorTexture(); // slower
-	
-	void drawYuv(); // fastest
-	void drawGray(); // fast
-	void drawColor(); // slower
+    ColorFrameCaptureMode colorFrameCaptureMode;
 };


### PR DESCRIPTION
Hi,

I'm currently using ofxBlackMagic to display and capture 3 video feeds at 1080p30 (using 3 UltraStudio Mini Recorders, ofxBlackMagic and ofxVideoRecorder). I needed a faster colour conversion. I looked at Elliot's ofxBlackMagic2 (Windows only right now) and tried my best to implement the colour conversion using the DeckLink SDK.

It works, but this is still a first attempt. It would be great if you could have a look.

Thanks,

Hugues.

![ofxBlackMagic_colourConversion](http://www.smallfly.com/of/ofxBlackMagic_colourConversion.png)
